### PR TITLE
Set algorithm container service to public for intercommunication.

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -7,21 +7,21 @@
     <services>
         <service id="pcdx_parameter_encryption.command.algorithm_list"
             class="Picodexter\ParameterEncryptionBundle\Command\AlgorithmListCommand"
-            public="false">
+            public="true">
             <argument type="service" id="pcdx_parameter_encryption.console.dispatcher.algorithm_list" />
             <tag name="console.command" />
         </service>
 
         <service id="pcdx_parameter_encryption.command.decrypt"
             class="Picodexter\ParameterEncryptionBundle\Command\DecryptCommand"
-            public="false">
+            public="true">
             <argument type="service" id="pcdx_parameter_encryption.console.dispatcher.decrypt" />
             <tag name="console.command" />
         </service>
 
         <service id="pcdx_parameter_encryption.command.encrypt"
             class="Picodexter\ParameterEncryptionBundle\Command\EncryptCommand"
-            public="false">
+            public="true">
             <argument type="service" id="pcdx_parameter_encryption.console.dispatcher.encrypt" />
             <tag name="console.command" />
         </service>


### PR DESCRIPTION
Hi picodexter,

It would be nice if we could have some useful services marked as public for better intercommunication among the bundles. I came across this when I tried to create a wrapper on encryption. One of such service was pcdx_parameter_encryption.configuration.algorithm_configuration_container.

Thanks,
Ranjith M